### PR TITLE
修复一个bug:点击重新播放按钮时,可能从任意的地方开始播放,而不是重头开始播放

### DIFF
--- a/nicevideoplayer/src/main/java/com/xiao/nicevideoplayer/NiceVideoPlayer.java
+++ b/nicevideoplayer/src/main/java/com/xiao/nicevideoplayer/NiceVideoPlayer.java
@@ -475,6 +475,8 @@ public class NiceVideoPlayer extends FrameLayout
             LogUtil.d("onCompletion ——> STATE_COMPLETED");
             // 清除屏幕常亮
             mContainer.setKeepScreenOn(false);
+            // 重置当前播放进度
+            NiceUtil.savePlayPosition(getContext(), mUrl, 0);
         }
     };
 


### PR DESCRIPTION
修复一个bug:点击重新播放按钮时,可能从任意的地方开始播放,而不是重头开始播放